### PR TITLE
Replace the "new project" reference to Waypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ and more.
 
 **API Status: Unstable.** We're still actively working on the API and
 may change it in backwards incompatible ways. See the roadmap section in
-particular for work that may impact the API. In particular, we're currently
-integrating this library into [a new HashiCorp project](https://twitter.com/mitchellh/status/1283093598922133504)
+particular for work that may impact the API. In particular, we have 
+integrated this library into [Waypoint](https://github.com/hashicorp/waypoint),
 and the experience of using this library in the real world will likely drive major
 changes.
 


### PR DESCRIPTION
Now that Waypoint is out, there's no need to be coy :)