### PR TITLE
Protect against nil LayoutRoots

### DIFF
--- a/document.go
+++ b/document.go
@@ -185,6 +185,9 @@ func (d *Document) RenderFrame() {
 
 	// Setup our root node
 	root := d.r.LayoutRoot()
+	if root == nil {
+		return
+	}
 
 	// Build our render tree
 	tree(ctx, root, Fragment(d.els...), false)

--- a/document_test.go
+++ b/document_test.go
@@ -1,6 +1,7 @@
 package glint
 
 import (
+	"bytes"
 	"context"
 	"sync/atomic"
 	"testing"
@@ -67,6 +68,23 @@ func TestDocument_unmountClose(t *testing.T) {
 	require.NoError(d.Close())
 	require.Equal(uint32(1), atomic.LoadUint32(&c.mount))
 	require.Equal(uint32(1), atomic.LoadUint32(&c.unmount))
+}
+
+func TestDocument_renderingWithoutLayout(t *testing.T) {
+	var buf bytes.Buffer
+
+	d := New()
+	d.SetRenderer(&TerminalRenderer{
+		Output: &buf,
+	})
+
+	var c testMount
+	d.Append(&c)
+
+	// Render once
+	d.RenderFrame()
+	require.Empty(t, buf.String())
+	require.Zero(t, atomic.LoadUint32(&c.mount))
 }
 
 type testMount struct {


### PR DESCRIPTION
When `Renderer.LayoutRoot()` is nil, [rendering should do nothing according to docs](https://github.com/mitchellh/go-glint/blob/b492b545f6208fc979e7ee498d55599b8107e770/renderer.go#L18-L19), but
currently it panics with nil pointer dereference.